### PR TITLE
Fix grid diffusion boundary conditions

### DIFF
--- a/src/controller/grid_state.gd
+++ b/src/controller/grid_state.gd
@@ -33,8 +33,7 @@ func add_decay():
 			self.current[x][y] = updated_value if updated_value >= 0.0 else 0.0 
 
 func add_diffusion():
-	# FIXME: from my tests it does not seem to be necessary to set the bounds to zero
-	# self.current = utils.set_matrix_edges_to_float(self.current, 0.0)
+	self.current = utils.set_matrix_edges_to_float(self.current, 0.0)
 	var diffusion_contribution: Array = utils.multiply_matrix_by_float(self.current, self.diffusion_coefficient)
 	var weighted_diffusion_contribution: Array = utils.multiply_matrix_by_float(diffusion_contribution, 0.25)
 	var remainder: Array = utils.subtract_matrix(self.current, diffusion_contribution)
@@ -48,8 +47,7 @@ func add_diffusion():
 			self.current[x][y] = remainder[x][y] + north[x][y] + east[x][y] + south[x][y] + west[x][y]
 
 func add_diffusion_and_decay():
-	# FIXME: from my tests it does not seem to be necessary to set the bounds to zero
-	# self.current = utils.set_matrix_edges_to_float(self.current, 0.0)
+	self.current = utils.set_matrix_edges_to_float(self.current, 0.0)
 	var diffusion_contribution: Array = utils.multiply_matrix_by_float(self.current, self.diffusion_coefficient)
 	var weighted_diffusion_contribution: Array = utils.multiply_matrix_by_float(diffusion_contribution, 0.25)
 	var remainder: Array = utils.subtract_matrix(self.current, diffusion_contribution)

--- a/src/controller/grid_state.gd
+++ b/src/controller/grid_state.gd
@@ -83,7 +83,10 @@ func add_diffusion_and_decay_kernel():
 func add_diffusion_and_decay_parallel():
 	var diffusion_coefficient_quarter: float = 0.25 * self.diffusion_coefficient
 	var threads = []
-
+	
+	# prevent diffusion across simulation box borders
+	current = utils.set_matrix_edges_to_float(current, 0.0)
+	
 	for i in range(NUM_THREADS):
 		var start_row: int = i * grid_size_x / NUM_THREADS
 		var end_row: int = (i + 1) * grid_size_x / NUM_THREADS
@@ -127,7 +130,7 @@ func add_emanate_pattern(cell_position: Vector2i, type_id: Cell.TYPES, cell_patt
 			var value: float = float(pattern_matrix[local_x][local_y]) / self.ntiles
 			if(is_position_valid(global_x, global_y)):
 				self.current[global_x][global_y] = min(self.current[global_x][global_y] + value, 1.0)
-
+	
 # Not that it matters, but we could check for valid positions in each loop to 
 # avoid three if statements per x,y iteration in add_emanate_pattern_to_grid.
 func is_position_valid(x: int, y: int) -> bool:
@@ -135,4 +138,12 @@ func is_position_valid(x: int, y: int) -> bool:
 		return false
 	if(y < 0 || y >= self.current[0].size()):
 		return false
+	return true
+
+func assert_grid_state() -> bool:
+	for x in range(grid_size_x):
+		for y in range(grid_size_y):
+			var value = current[x][y]
+			if value < 0.0 or value > 1.0:
+				return false
 	return true

--- a/src/utils/matrix_utils.gd
+++ b/src/utils/matrix_utils.gd
@@ -70,14 +70,14 @@ static func roll_matrix(m, shift: int, axis: int) -> Array:
 		printerr("Unsupported axis value. Please use 0 or 1 for axis.")
 		return []
 
-# TODO: This implementation is very inefficient since we iterate over the whole 
-# matrix.
 static func set_matrix_edges_to_float(m: Array, v: float) -> Array:
 	var dim_x: int = m.size()
 	var dim_y: int = m[0].size()
 	var r = m.duplicate(true)
-	for x in dim_x:
-		for y in dim_y:
-			if x == 0 or x == dim_x - 1 or y == 0 or y == dim_y - 1:
-				r[x][y] = 0.0
+	r[0].fill(v) # first row
+	r[dim_x-1].fill(v) # last row
+	for x in range(1, dim_x - 1):
+		r[x][0] = v # first column
+		r[x][dim_y-1] = v # last column
+	
 	return r


### PR DESCRIPTION
Setting the grid state edges to 0.0 before adding the diffusion update fixes the diffusion across the simulation box borders. The outer edges are not within the rendered tiles anyway, so it has no impact on the visuals.